### PR TITLE
Split traits namespace from struct creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,28 @@ namespace types {
 
 ## Multiple structs per namespace
 
-Currently, the template `value_type` **does not** allow multiple `F1D_STRUCT_MAKE` declarations in a single namespace because there will be multiple definitions of the base template trait inside the `traits` namespace. This may change in the future if I can find a solution that does not sacrifice simplicity.
+By default, calling `F1D_STRUCT_MAKE` will generate a `traits` namespace with template declarations that are incompatible with multiple structs. To solve this problem, it is possible to create the `traits` namespace first using the `F1D_TRAITS_MAKE()` macro and then use multiple calls to `F1D_STRUCT_MAKE_NT` (NT stands for no-traits) to create the structs:
+
+```c++
+F1D_TRAITS_MAKE()
+
+F1D_STRUCT_MAKE_NT(first_struct,
+    3, (
+        (a, int),
+        (b, int),
+        (c, int)
+    )
+) // first_struct
+
+F1D_STRUCT_MAKE_NT(second_struct,
+    2, (
+        (d, int),
+        (e, int)
+    )
+) // second_struct
+```
+
+Although this solves the problem with the `traits` namespace, it is still possible for typedef collisions to occur inside the `types` namespace. Unfortunately at the moment there is still no solution for this particular case.
 
 ## Struct factory
 

--- a/fields.hpp
+++ b/fields.hpp
@@ -62,6 +62,27 @@
         SName, \
         i)
 
+#define F1D_NO_TRAITS()
+
+#define F1D_BASE_TRAITS() \
+namespace traits { \
+template <class T, unsigned int N> \
+    struct value_type \
+    { \
+        typedef void type; \
+    }; \
+    template <class T> \
+    struct field_type \
+    { \
+        typedef typename T::value_type type; \
+    }; \
+    template <class T> \
+    struct field_index \
+    { \
+        static const unsigned int value = T::index; \
+    }; \
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 #define F1D_STRUCT_DECL_VAR(Type, Name) \
@@ -223,7 +244,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#define F1D_STRUCT_MAKE_S1(Name, NF, Fields) \
+#define F1D_STRUCT_MAKE_S1(Name, NF, Fields, Traits) \
 namespace types { \
     BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_TYPES, 0, Fields) \
 } \
@@ -383,24 +404,18 @@ public: \
     } \
     BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_INITS, types, Fields) \
 }; \
+Traits() \
 namespace traits { \
-    template <class T, unsigned int N> \
-    struct value_type \
-    { \
-        typedef void type; \
-    }; \
-    template <class T> \
-    struct field_type \
-    { \
-        typedef typename T::value_type type; \
-    }; \
-    template <class T> \
-    struct field_index \
-    { \
-        static const unsigned int value = T::index; \
-    }; \
     BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_TRAITS, Name, Fields) \
 }
 
 #define F1D_STRUCT_MAKE(Name, NF, Fields) \
-    F1D_STRUCT_MAKE_S1(Name, NF, BOOST_PP_TUPLE_TO_SEQ(NF, Fields))
+    F1D_STRUCT_MAKE_S1(Name, NF, BOOST_PP_TUPLE_TO_SEQ(NF, Fields), \
+        F1D_BASE_TRAITS)
+
+#define F1D_STRUCT_MAKE_NT(Name, NF, Fields) \
+    F1D_STRUCT_MAKE_S1(Name, NF, BOOST_PP_TUPLE_TO_SEQ(NF, Fields), \
+        F1D_NO_TRAITS)
+
+#define F1D_TRAITS_MAKE() \
+    F1D_BASE_TRAITS()


### PR DESCRIPTION
This creates `F1D_STRUCT_MAKE_NT` and `F1D_TRAITS_MAKE` that enables multiple struct declarations in the same namespace without collision because of the traits namespace.

There may be still other collisions to be treated!