### PR TITLE
Add field wrapper overload to set factory fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,19 +234,24 @@ field1_1.get() = v1;
 const float vf1 = field1_1.get();
 ```
 
-They can be used as functors to apply their field value to either a reference to the same underlying type, or even a f1d-generated struct, making them handy when applying transforms:
+They can be used as functors to apply their field value to variables, to their matching f1d-generated struct, and to their matching f1d-generated factory, making them very handy when applying transforms:
 
 ```c++
 test::types::field1_f field1(1.3);
 
 float vf1;
 test::my_struct ms;
+test::my_struct_factory fms;
 
 field1(vf1);
 field1(ms);
+
+fms.begin();
+field1(fms);
+fms.end();
 ```
 
-They also have a special `set_member` method that allows fields to set their values to any kind of struct, as long as the name of the member matches the original f1d-generated struct one:
+They also have a special `set_member` method that allows fields to set their field value to any kind of struct, as long as the name of the member matches the name of the original f1d-generated struct:
 
 ```c++
 struct some_struct

--- a/fields.hpp
+++ b/fields.hpp
@@ -38,6 +38,9 @@
 #define F1D_STRUCT_TYPE_NAME(Name) \
     BOOST_PP_CAT(Name, _t)
 
+#define F1D_STRUCT_FACTORY_NAME(Name) \
+    BOOST_PP_CAT(Name, _factory)
+
 #define F1D_STRUCT_FULL_TYPE(Namespace, Name) \
     Namespace::F1D_STRUCT_TYPE_NAME(Name)
 
@@ -170,6 +173,9 @@ namespace traits { \
         } \
         void operator ()(StructName& obj) { \
             obj.Name = _value; \
+        } \
+        void operator ()(F1D_STRUCT_FACTORY_NAME(StructName)& obj) { \
+            obj.BOOST_PP_CAT(set_, Name)(_value); \
         } \
         template <typename T> \
         void set_member(T& obj) { \
@@ -384,10 +390,7 @@ struct Name { \
             Fields) \
     } \
 }; \
-namespace types { \
-    BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_SUPER_FIELDS, Name, Fields) \
-} \
-class BOOST_PP_CAT(Name,_factory) { \
+class F1D_STRUCT_FACTORY_NAME(Name) { \
 private: \
     Name _obj; \
     bool _begun; \
@@ -423,7 +426,7 @@ private: \
         } \
     } \
 public: \
-    inline BOOST_PP_CAT(Name,_factory)() : \
+    inline F1D_STRUCT_FACTORY_NAME(Name)() : \
         _obj(), \
         _begun(false), \
         _ended(false), \
@@ -467,6 +470,9 @@ public: \
     } \
     BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_INITS, types, Fields) \
 }; \
+namespace types { \
+    BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_SUPER_FIELDS, Name, Fields) \
+} \
 Traits() \
 namespace traits { \
     BOOST_PP_SEQ_FOR_EACH_I(F1D_STRUCT_ASSEMBLE_TRAITS, (Name, types), \

--- a/test/struct_1_field.cpp
+++ b/test/struct_1_field.cpp
@@ -698,3 +698,25 @@ TEST(Struct1FieldsTest, CApplyMethod)
 
     EXPECT_EQ(f3.total, (v1 + 1));
 }
+
+/**
+ * Test factory set from field wrappers without error
+ */
+TEST(Struct1FieldsTest, FactoryFromFieldOK)
+{
+    const double v1 = 1.4;
+
+    test::my_struct_1 ms;
+    test::my_struct_1_factory f;
+
+    test::types::field1_f field1(v1);
+
+    ASSERT_NO_THROW(f.begin());
+    ASSERT_NO_THROW(field1(f));
+    ASSERT_NO_THROW(f.end());
+    ASSERT_NO_THROW(ms = f.get());
+
+    EXPECT_EQ(f.get_field1(), v1);
+
+    EXPECT_EQ(ms.field1, v1);
+}

--- a/test/struct_3_fields.cpp
+++ b/test/struct_3_fields.cpp
@@ -1214,3 +1214,35 @@ TEST(Struct3FieldsTest, CApplyMethod)
 
     EXPECT_EQ(f3.total, (v1 + 1 + v2 + 1 + v3 + 1));
 }
+
+/**
+ * Test factory set from field wrappers without error
+ */
+TEST(Struct3FieldsTest, FactoryFromFieldOK)
+{
+    const float v1 = 1.4f;
+    const int   v2 = -7;
+    const char  v3 = 'H';
+
+    test::my_struct_3 ms;
+    test::my_struct_3_factory f;
+
+    test::types::field1_f field1(v1);
+    test::types::field2_f field2(v2);
+    test::types::field3_f field3(v3);
+
+    ASSERT_NO_THROW(f.begin());
+    ASSERT_NO_THROW(field1(f));
+    ASSERT_NO_THROW(field2(f));
+    ASSERT_NO_THROW(field3(f));
+    ASSERT_NO_THROW(f.end());
+    ASSERT_NO_THROW(ms = f.get());
+
+    EXPECT_EQ(f.get_field1(), v1);
+    EXPECT_EQ(f.get_field2(), v2);
+    EXPECT_EQ(f.get_field3(), v3);
+
+    EXPECT_EQ(ms.field1, v1);
+    EXPECT_EQ(ms.field2, v2);
+    EXPECT_EQ(ms.field3, v3);
+}


### PR DESCRIPTION
The call operator of field wrappers now accepts a matching struct factory as argument and will call its correspondent `set_` method.