### PR TITLE
Convert F1D_STRUCT_MAKE to use sequences instead of tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ master          | [![Build Status](https://travis-ci.org/Caian/f1d.svg?branch=ma
 
 ## Introduction
 
-This project allows the creation of structs from tuples, where each name and type in the tuple expand to an individual field in the struct.
+This project allows the creation of structs from sequences of tuples, where each name and type in the tuple expand to an individual field in the struct.
 
 Additional methods allow quick access to the field count, original field names, field types (as typed in the source code), field sizes (though sizeof), and allow searching for the index of the field by its name.
 
@@ -21,17 +21,15 @@ This project requires [boost](https://www.boost.org/) for the preprocessor capab
 
 ## Usage
 
-The macro `F1D_STRUCT_MAKE` is used to generate the struct, the factory, a nested namespace `types` containing one type per field, and a nested namespace `traits` with a metafunction used to query the type of a given field index and the number of fields in the struct.
+The macro `F1D_STRUCT_MAKE` is used to generate the struct, the factory, a nested namespace `types` containing one type per field, and a nested namespace `traits` with metafunctions used to query the type of a given field index and the number of fields in the struct.
 
 For instance, the following call:
 
 ```c++
 F1D_STRUCT_MAKE(my_struct_3,
-    3, (
-        (field1, float),
-        (field2, int  ),
-        (field3, char )
-    )
+    ( (field1, float) )
+    ( (field2, int  ) )
+    ( (field3, char ) )
 ) // my_struct_3
 ```
 
@@ -168,18 +166,14 @@ By default, calling `F1D_STRUCT_MAKE` will generate a `traits` namespace with te
 F1D_TRAITS_MAKE()
 
 F1D_STRUCT_MAKE_NT(first_struct,
-    3, (
-        (a, int),
-        (b, int),
-        (c, int)
-    )
+    ( (a, int) )
+    ( (b, int) )
+    ( (c, int) )
 ) // first_struct
 
 F1D_STRUCT_MAKE_NT(second_struct,
-    2, (
-        (d, int),
-        (e, int)
-    )
+    ( (d, int) )
+    ( (e, int) )
 ) // second_struct
 ```
 

--- a/fields.hpp
+++ b/fields.hpp
@@ -23,7 +23,7 @@
 #include "exceptions.hpp"
 
 #include <boost/preprocessor/tuple/elem.hpp>
-#include <boost/preprocessor/tuple/to_seq.hpp>
+#include <boost/preprocessor/seq/size.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/punctuation/comma.hpp>
@@ -479,12 +479,12 @@ namespace traits { \
         Fields) \
 }
 
-#define F1D_STRUCT_MAKE(Name, NF, Fields) \
-    F1D_STRUCT_MAKE_S1(Name, NF, BOOST_PP_TUPLE_TO_SEQ(NF, Fields), \
+#define F1D_STRUCT_MAKE(Name, Fields) \
+    F1D_STRUCT_MAKE_S1(Name, BOOST_PP_SEQ_SIZE(Fields), Fields, \
         F1D_BASE_TRAITS)
 
 #define F1D_STRUCT_MAKE_NT(Name, NF, Fields) \
-    F1D_STRUCT_MAKE_S1(Name, NF, BOOST_PP_TUPLE_TO_SEQ(NF, Fields), \
+    F1D_STRUCT_MAKE_S1(Name, BOOST_PP_SEQ_SIZE(Fields), Fields, \
         F1D_NO_TRAITS)
 
 #define F1D_TRAITS_MAKE() \

--- a/test/struct_1_field.cpp
+++ b/test/struct_1_field.cpp
@@ -41,9 +41,7 @@
 namespace test {
 
 F1D_STRUCT_MAKE(my_struct_1,
-    1, (
-        (field1, double)
-    )
+    ( (field1, double) )
 ) // my_struct_1
 
 struct some_struct_1

--- a/test/struct_3_fields.cpp
+++ b/test/struct_3_fields.cpp
@@ -41,11 +41,9 @@
 namespace test {
 
 F1D_STRUCT_MAKE(my_struct_3,
-    3, (
-        (field1, float),
-        (field2, int  ),
-        (field3, char )
-    )
+    ( (field1, float) )
+    ( (field2, int  ) )
+    ( (field3, char ) )
 ) // my_struct_3
 
 struct some_struct_3


### PR DESCRIPTION
Tuples require an explicit number of elements to operate, this is more error prone than using sequences, where the number of elements can be determined from the sequence itself.